### PR TITLE
Add terms of user page and handle missing confirmation

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import { HTTPClient } from "./httpClient";
 import { IUpdateUserBody } from "./requests";
-import { IUser, Report } from "./responses";
+import { IUser, Report, TermsOfUse } from "./responses";
 
 export class APIClient {
   private httpClient: HTTPClient;
@@ -19,6 +19,10 @@ export class APIClient {
 
   confirmTermsOfUse(token: string): Promise<IUser> {
     return this.httpClient.patch("user/confirm-terms", token) as Promise<IUser>;
+  }
+
+  getTermsOfUse(): Promise<TermsOfUse> {
+    return this.httpClient.get("config/terms", "") as Promise<TermsOfUse>;
   }
 
   sendImage(

--- a/src/api/responses.ts
+++ b/src/api/responses.ts
@@ -114,3 +114,16 @@ export type Report = {
     curl?: object;
   };
 };
+
+export type TermsOfUse = {
+  terms: { li: string | TermType }[];
+  updated: string;
+};
+
+export type TermType = {
+  text?: string;
+  link?: {
+    url: string;
+    text: string;
+  };
+}[];

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -37,6 +37,7 @@ function App() {
           <Route component={Page.Mandate} path={ROUTES.mandate} />
           <Route component={Page.PrivacyPolicy} path={ROUTES.privavyPolicy} />
           <Route component={Page.Report} path={ROUTES.newReport} />
+          <Route component={Page.TermsOfUsePage} path={ROUTES.termsOfUse} />
           <Page.User path={ROUTES.user.main}>
             <Page.UserProfile path={ROUTES.user.home} />
             <Page.UserRegistration path={ROUTES.user.edit} />

--- a/src/components/Navbar/CommonLinks.tsx
+++ b/src/components/Navbar/CommonLinks.tsx
@@ -43,7 +43,7 @@ function CommonLinks({ closeNav }: Props) {
         </S.Item>
 
         <S.Item>
-          <Link onClick={closeNav} to={ROUTES.websiteRegulations}>
+          <Link onClick={closeNav} to={ROUTES.termsOfUse}>
             ‣&nbsp;&nbsp;&nbsp;Regulamin
           </Link>
         </S.Item>

--- a/src/components/TermsOfUse/TermsOfUse.tsx
+++ b/src/components/TermsOfUse/TermsOfUse.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useAsync } from "react-use";
+import { useAppDispatch } from "../../store";
+import { confirmTermsOfUse } from "../../store/user";
+import { apiClient } from "../../api";
+import { LinearLoader } from "../Loader";
+import { TermType } from "../../api/responses";
+import { Action, Date, Item, Link, List, Title } from "./styles";
+
+type Props = {
+  withConfirmation?: boolean;
+};
+
+export function TermsOfUse({ withConfirmation = true }: Props) {
+  const dispatch = useAppDispatch();
+  const { value, loading, error } = useAsync(() => apiClient.getTermsOfUse());
+
+  function handleConfirmation() {
+    dispatch(confirmTermsOfUse());
+  }
+
+  if (loading) {
+    return <LinearLoader />;
+  }
+
+  if (!!error || !value) {
+    return <p>{error.message || "Nie udało się pobrać danych."}</p>;
+  }
+
+  return (
+    <section>
+      <Title>Regulamin serwisu Uprzejmie Donoszę</Title>
+
+      <List>
+        {value.terms.map(({ li }, i) => {
+          if (typeof li === "string") return <Item key={li}>{li}</Item>;
+
+          const content = (li as TermType).map((element) => (
+            <>
+              {element.text && <span>{element.text}</span>}
+              {element.link && (
+                <Link to={element.link.url}>&nbsp;{element.link.text}</Link>
+              )}
+            </>
+          ));
+          return <Item key={i}>{content}</Item>;
+        })}
+      </List>
+
+      <Date>
+        Aktualizacja: <strong>{value.updated}</strong>
+      </Date>
+
+      {withConfirmation && (
+        <Action onClick={handleConfirmation}>potwierdź</Action>
+      )}
+    </section>
+  );
+}

--- a/src/components/TermsOfUse/index.ts
+++ b/src/components/TermsOfUse/index.ts
@@ -1,0 +1,1 @@
+export { TermsOfUse } from "./TermsOfUse";

--- a/src/components/TermsOfUse/styles.ts
+++ b/src/components/TermsOfUse/styles.ts
@@ -1,0 +1,39 @@
+import { Link as RouterLink } from "@reach/router";
+import styled from "styled-components";
+import { Button, colors } from "../../styles";
+
+export const Title = styled.h1`
+  font-weight: 300;
+  text-align: center;
+  margin: 30px 0;
+`;
+
+export const List = styled.ul`
+  list-style: decimal;
+  margin: 0 auto;
+  max-width: 800px;
+  padding-left: 15px;
+`;
+
+export const Item = styled.li`
+  font-weight: 300;
+
+  & + & {
+    margin-top: 10px;
+  }
+`;
+
+export const Link = styled(RouterLink)`
+  color: ${colors.primary};
+`;
+
+export const Date = styled.p`
+  font-weight: 300;
+  text-align: center;
+  margin: 30px 0;
+`;
+
+export const Action = styled(Button)`
+  display: block;
+  margin: 0 auto;
+`;

--- a/src/config/auth.tsx
+++ b/src/config/auth.tsx
@@ -5,6 +5,7 @@ import { LinearLoader } from "../components/Loader";
 import { ROUTES } from "./routes";
 import { useAppDispatch, useAppSelector } from "../store";
 import { getUser } from "../store/user";
+import { TermsOfUse } from "../components/TermsOfUse";
 
 export function withAuth(Component: React.ElementType) {
   function WithAuth(props: any) {
@@ -24,6 +25,8 @@ export function withAuth(Component: React.ElementType) {
     ) {
       return <Redirect from={location.pathname} to={ROUTES.userEdit} noThrow />;
     }
+
+    if (!user.isEmpty && !user.profile.isTermsConfirmed) return <TermsOfUse />;
 
     return <Component {...props} />;
   }

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -7,7 +7,7 @@ export const ROUTES = {
   privavyPolicy: "/polityka-prywatnosci",
   project: "/projekt",
   regulations: "/przepisy",
-  websiteRegulations: "/regulamin",
+  termsOfUse: "/regulamin",
   stats: "/statystyki",
   statusCheck: "/zapytaj-o-status",
   install: "/aplikacja",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import { LinearLoader } from "../components/Loader";
 import { ROUTES } from "../config";
 import { colors } from "../styles";
 import { useAppSelector } from "../store";
+import { TermsOfUse } from "../components/TermsOfUse";
 
 export function Home() {
   const user = useAppSelector((state) => state.user);
@@ -18,6 +19,8 @@ export function Home() {
 
   if (!user.isEmpty && !user.profile.isRegistered)
     return <Redirect from={ROUTES.home} to={ROUTES.userEdit} noThrow />;
+
+  if (!user.isEmpty && !user.profile.isTermsConfirmed) return <TermsOfUse />;
 
   return (
     <div>

--- a/src/pages/TermsOfUse.tsx
+++ b/src/pages/TermsOfUse.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { TermsOfUse } from "../components/TermsOfUse";
+
+export function TermsOfUsePage() {
+  return <TermsOfUse withConfirmation={false} />;
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -10,3 +10,4 @@ export * from "./User";
 export * from "./UserProfile";
 export * from "./UserRegistration";
 export * from "./UserReports";
+export * from "./TermsOfUse";


### PR DESCRIPTION
# Changes
- added terms of use page,
- handled a behaviour of missing user confirmation.

## Confirmation bahaviour

A component with action to confirm terms of use is displayed on each page that requires user authentication instead of page's content.

## Page preview

<img width="1432" alt="Screenshot 2024-01-06 at 20 23 34" src="https://github.com/uprzejmie-donosze/uprzejmiedonosze-frontend/assets/20128959/8a233c0c-d4f9-48a2-8225-896a84b06d96">
