### PR TITLE
Sort categories in a proper order

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,6 +1,6 @@
 import { HTTPClient } from "./httpClient";
 import { IUpdateUserBody } from "./requests";
-import { Categories, IUser, Report, TermsOfUse } from "./responses";
+import { Category, IUser, Report, TermsOfUse } from "./responses";
 
 export class APIClient {
   private httpClient: HTTPClient;
@@ -51,7 +51,7 @@ export class APIClient {
     return this.httpClient.get(`app/${id}`, token) as Promise<Report>;
   }
 
-  getCategories(): Promise<Categories> {
-    return this.httpClient.get("config/categories", "") as Promise<Categories>;
+  getCategories(): Promise<[Category]> {
+    return this.httpClient.get("config/categories", "") as Promise<[Category]>;
   }
 }

--- a/src/api/responses.ts
+++ b/src/api/responses.ts
@@ -127,11 +127,9 @@ export type TermType = {
     text: string;
   };
 }[];
-export type Categories = {
-  [key: string]: Category;
-};
 
 export type Category = {
+  id: string;
   title: string;
   short: string;
   desc: string;
@@ -142,4 +140,5 @@ export type Category = {
   contextImageHint: string;
   carImageHint: string;
   stopAgresjiOnly: boolean;
+  order: number;
 };

--- a/src/components/report/components/Categories.tsx
+++ b/src/components/report/components/Categories.tsx
@@ -42,15 +42,15 @@ export function Categories() {
       <S.CategoriesTitle>Wybierz rodzaj naruszenia</S.CategoriesTitle>
 
       <S.CategoriesGrid>
-        {Object.entries(categories).map(([key, value]) => {
-          if (!value.title) return;
+        {categories.map((category) => {
+          if (!category.title) return;
           return (
             <S.CategoryItem
-              key={key}
-              title={value.desc}
-              selected={selected === key}
+              key={category.id}
+              title={category.desc}
+              selected={selected === category.id}
             >
-              {value.stopAgresjiOnly !== stopAgression && selected === key && (
+              {category.stopAgresjiOnly !== stopAgression && selected === category.id && (
                 <S.CategoryWarning>
                   ⚠︎ Miejsce wysyłki (Policja) inne niż wskazane w ustawieniach
                   konta (Straż Miejska/Gminna).
@@ -59,23 +59,23 @@ export function Categories() {
               <RadioInputField
                 handleChange={() =>
                   handleCategoryChange(
-                    key,
-                    value.contextImageHint,
-                    value.carImageHint,
+                    category.id,
+                    category.contextImageHint,
+                    category.carImageHint,
                   )
                 }
                 contentData={{
-                  id: key,
+                  id: category.id,
                   label: (
                     <Category
-                      image={`${IMAGE_HOST}/img/${key}.jpg`}
-                      description={value.title}
-                      note={value.price ? `💰 mandat: ${value.price}` : ""}
+                      image={`${IMAGE_HOST}/img/${category.id}.jpg`}
+                      description={category.title}
+                      note={category.price ? `💰 mandat: ${category.price}` : ""}
                     />
                   ),
-                  name: key,
-                  selected: selected === key,
-                  value: key,
+                  name: category.id,
+                  selected: selected === category.id,
+                  value: category.id,
                 }}
               />
             </S.CategoryItem>

--- a/src/store/categories/categoriesActions.ts
+++ b/src/store/categories/categoriesActions.ts
@@ -8,7 +8,11 @@ export function getCategories() {
     try {
       dispatch({ type: CATEGORIES_ACTIONS.loading });
       const categories = await apiClient.getCategories();
-      dispatch({ type: CATEGORIES_ACTIONS.loaded, payload: { categories } });
+      const sorted = categories.sort((a, b) => a.order - b.order);
+      dispatch({
+        type: CATEGORIES_ACTIONS.loaded,
+        payload: { categories: sorted },
+      });
     } catch (error) {
       dispatch({ type: CATEGORIES_ACTIONS.error });
       dispatch({ type: FALLBACK_ACTIONS.error });

--- a/src/store/categories/categoriesReducer.ts
+++ b/src/store/categories/categoriesReducer.ts
@@ -1,4 +1,4 @@
-import { Categories } from "../../api/responses";
+import { Category } from "../../api/responses";
 import { CATEGORIES_ACTIONS } from "./actionTypes";
 import { CategoriesState } from "./types";
 
@@ -21,7 +21,7 @@ export function categoriesReducer(state = initialState, action: any) {
         ...state,
         loading: false,
         loaded: true,
-        categories: { ...(action.payload.categories as Categories) },
+        categories: action.payload.categories as [Category],
       };
     case CATEGORIES_ACTIONS.error:
       return {

--- a/src/store/categories/types.ts
+++ b/src/store/categories/types.ts
@@ -1,7 +1,7 @@
-import { Categories } from "../../api/responses";
+import { Category } from "../../api/responses";
 
 export type CategoriesState = {
   loading: boolean;
   loaded: boolean;
-  categories: Categories | null;
+  categories: [Category] | null;
 };


### PR DESCRIPTION
Self-descriptive. Updates on API were needed. Instead of the `Categories` object with a key and `Category` as a value, categories are now represented by `[Category]` array. The Category class was extended with `id` and `order` properties.